### PR TITLE
fix include pcl as thirdparty dep through fetchcontent

### DIFF
--- a/cpp/3rdparty/find_dependencies.cmake
+++ b/cpp/3rdparty/find_dependencies.cmake
@@ -46,7 +46,8 @@ find_external_dependency("OpenCV" "opencv_features2d"
                          "${CMAKE_CURRENT_LIST_DIR}/opencv/opencv.cmake")
 find_external_dependency("tsl-robin-map" "tsl::robin_map"
                          "${CMAKE_CURRENT_LIST_DIR}/tsl_robin/tsl_robin.cmake")
-#find_external_dependency("PCL" "pcl_common" "${CMAKE_CURRENT_LIST_DIR}/pcl/pcl.cmake")
-find_external_dependency("optimization" "graph" "${CMAKE_CURRENT_LIST_DIR}/optimization/optimization.cmake")
+find_external_dependency("PCL" "pcl_common" "${CMAKE_CURRENT_LIST_DIR}/pcl/pcl.cmake")
+find_external_dependency("optimization" "graph"
+                         "${CMAKE_CURRENT_LIST_DIR}/optimization/optimization.cmake")
 
 include(${CMAKE_CURRENT_LIST_DIR}/hbst/hbst.cmake)

--- a/cpp/3rdparty/pcl/LICENSE
+++ b/cpp/3rdparty/pcl/LICENSE
@@ -9,7 +9,7 @@ All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
-are met: 
+are met:
 
  * Redistributions of source code must retain the above copyright
    notice, this list of conditions and the following disclaimer.

--- a/cpp/3rdparty/pcl/pcl.cmake
+++ b/cpp/3rdparty/pcl/pcl.cmake
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2024 Javier Laserna
+# Copyright (c) 2025 Javier Laserna, Saurabh Gupta
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,17 +21,34 @@
 # SOFTWARE.
 
 include(FetchContent)
-FetchContent_Declare(pcl URL https://github.com/PointCloudLibrary/pcl/archive/refs/tags/pcl-1.10.1.tar.gz UPDATE_DISCONNECTED 1)
-FetchContent_GetProperties(pcl)
-if(NOT pcl_POPULATED)
-  FetchContent_Populate(pcl)
-  if(${CMAKE_VERSION} GREATER_EQUAL 3.25)
-    add_subdirectory(${pcl_SOURCE_DIR} ${pcl_BINARY_DIR} SYSTEM EXCLUDE_FROM_ALL)
-  else()
-    # Emulate the SYSTEM flag introduced in CMake 3.25. Withouth this flag the compiler will
-    # consider this 3rdparty headers as source code and fail due the -Werror flag.
-    add_subdirectory(${pcl_SOURCE_DIR} ${pcl_BINARY_DIR} EXCLUDE_FROM_ALL)
-    get_target_property(pcl_include_dirs pcl INTERFACE_INCLUDE_DIRECTORIES)
-    set_target_properties(pcl PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${pcl_include_dirs}")
-  endif()
-endif()
+FetchContent_Declare(
+  pcl URL https://github.com/PointCloudLibrary/pcl/archive/refs/tags/pcl-1.10.1.tar.gz
+  UPDATE_DISCONNECTED 1)
+FetchContent_MakeAvailable(pcl)
+
+add_library(PCL INTERFACE)
+target_link_libraries(
+  PCL
+  INTERFACE pcl_features
+            pcl_filters
+            pcl_keypoints
+            pcl_common
+            pcl_search
+            pcl_kdtree
+            pcl_io
+            pcl_registration)
+
+target_include_directories(
+  PCL
+  INTERFACE ${pcl_SOURCE_DIR}
+            ${pcl_SOURCE_DIR}/features/include
+            ${pcl_SOURCE_DIR}/filters/include
+            ${pcl_SOURCE_DIR}/keypoints/include
+            ${pcl_SOURCE_DIR}/common/include
+            ${pcl_SOURCE_DIR}/search/include
+            ${pcl_SOURCE_DIR}/kdtree/include
+            ${pcl_SOURCE_DIR}/io/include
+            ${pcl_SOURCE_DIR}/registration/include
+            ${pcl_BINARY_DIR}/include/)
+
+set(PCL_LIBS PCL)

--- a/cpp/3rdparty/pcl/pcl.cmake
+++ b/cpp/3rdparty/pcl/pcl.cmake
@@ -20,9 +20,34 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# PCL build options and deps
+set(PCL_ALLOW_BOTH_SHARED_AND_STATIC_DEPENDENCIES ON CACHE BOOL "Do not force PCL dependencies to be all shared or all static")
+set(PCL_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
+set(WITH_OPENGL OFF CACHE BOOL "Support for OpenGL")
+set(WITH_GLEW OFF CACHE BOOL "Support for GLEW")
+set(WITH_VTK OFF CACHE BOOL "Build VTK visualizations")
+set(WITH_QT OFF CACHE BOOL "Support for QT")
+set(WITH_PCAP OFF CACHE BOOL "PCAP file support")
+set(WITH_PNG OFF CACHE BOOL "PNG file support")
+set(WITH_LIBUSB OFF CACHE BOOL "USB RGB-D camera drivers")
+set(WITH_SYSTEM_ZLIB OFF CACHE BOOL "Use system ZLIB")
+set(WITH_CUDA OFF CACHE BOOL "Build NVIDIA-CUDA support")
+set(WITH_SYSTEM_CJSON OFF CACHE BOOL "Use system cJSON")
+set(WITH_QHULL OFF CACHE BOOL "Include convex-hull operations")
+
+# PCL Modules' build options
+set(BUILD_stereo OFF CACHE BOOL "Point cloud stereo library")
+set(BUILD_recognition OFF CACHE BOOL "Point cloud recognition library")
+set(BUILD_tools OFF CACHE BOOL "Point cloud tools library")
+set(BUILD_ml OFF CACHE BOOL "Point cloud ml library")
+set(BUILD_tracking OFF CACHE BOOL "Point cloud tracking library")
+set(BUILD_surface OFF CACHE BOOL "Point cloud surface library")
+set(BUILD_segmentation OFF CACHE BOOL "Point cloud segmentation library")
+
+
 include(FetchContent)
 FetchContent_Declare(
-  pcl URL https://github.com/PointCloudLibrary/pcl/archive/refs/tags/pcl-1.10.1.tar.gz
+  pcl URL https://github.com/PointCloudLibrary/pcl/archive/refs/tags/pcl-1.14.1.tar.gz
   UPDATE_DISCONNECTED 1)
 FetchContent_MakeAvailable(pcl)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -22,7 +22,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.16...3.26)
-project(map_closures_cpp VERSION 1.0.0 LANGUAGES CXX)
+project(map_closures_cpp VERSION 1.0.0 LANGUAGES CXX C)
 
 option(USE_SYSTEM_EIGEN3 "Use system pre-installed Eigen" ON)
 option(USE_SYSTEM_TBB "Use system pre-installed TBB" ON)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -34,10 +34,5 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include(3rdparty/find_dependencies.cmake)
 
-find_package(PCL 1.12 REQUIRED)
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_subdirectory(map_closures)
 add_subdirectory(gt_closures)

--- a/cpp/map_closures/CMakeLists.txt
+++ b/cpp/map_closures/CMakeLists.txt
@@ -22,7 +22,10 @@
 # SOFTWARE.
 
 add_library(map_closures STATIC)
-target_sources(map_closures PRIVATE DensityMap.cpp AlignRansac.cpp AlignCliReg.cpp MapClosures.cpp PointPair.cpp)
-target_include_directories(map_closures PUBLIC ${hbst_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/.. ${OPTIMIZATION_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS})
-target_link_libraries(map_closures PUBLIC Eigen3::Eigen TBB::tbb ${OpenCV_LIBS} ${OPTIMIZATION_LIBRARIES} ${PCL_LIBRARIES})
+target_sources(map_closures PRIVATE DensityMap.cpp AlignRansac.cpp AlignCliReg.cpp MapClosures.cpp
+                                    PointPair.cpp)
+target_include_directories(map_closures PUBLIC ${hbst_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..
+                                               ${OPTIMIZATION_INCLUDE_DIRS})
+target_link_libraries(map_closures PUBLIC Eigen3::Eigen TBB::tbb ${OpenCV_LIBS}
+                                          ${OPTIMIZATION_LIBRARIES} ${PCL_LIBS})
 target_compile_features(map_closures PUBLIC cxx_std_17)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -21,7 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 cmake_minimum_required(VERSION 3.16...3.26)
-project(map_closure_pybind VERSION 1.0.0 LANGUAGES CXX)
+project(map_closure_pybind VERSION 1.0.0 LANGUAGES CXX C)
 
 # Set build type
 set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
I make some changes to pcl.cmake file to solve errors I faced with FetchContent of PCL library.
PCL can now stay as a third-party-only library, without having to install it locally on the machine beforehand.